### PR TITLE
changed double equals comparison to triple for this.options[key] 

### DIFF
--- a/src/okvideo.js
+++ b/src/okvideo.js
@@ -57,8 +57,8 @@ var player, OKEvents, options;
     base.setOptions = function () {
       // exchange 'true' for '1' and 'false' for 3
       for (var key in this.options){
-        if (this.options[key] == true) this.options[key] = 1;
-        if (this.options[key] == false) this.options[key] = 3;
+        if (this.options[key] === true) this.options[key] = 1;
+        if (this.options[key] === false) this.options[key] = 3;
       }
 
       if (base.options.playlist.list === null) { 


### PR DESCRIPTION
when volume 0 was passed to this comparison it was changed to 3 causing the player to not be muted. changed this to a triple equals which only accepts direct equality.
