### PR TITLE
No conflict jQuery issue fixes

### DIFF
--- a/src/okvideo.js
+++ b/src/okvideo.js
@@ -177,14 +177,14 @@ var player, OKEvents, options;
 
 // vimeo player ready
 function vimeoPlayerReady() {
-  options = $(window).data('okoptions');
+  options = jQuery(window).data('okoptions');
 
-  var iframe = $('#okplayer')[0];
+  var iframe = jQuery('#okplayer')[0];
   player = $f(iframe);
 
   // hide player until Vimeo hides controls...
   window.setTimeout(function(){
-    $('#okplayer').css('visibility', 'visible');
+    jQuery('#okplayer').css('visibility', 'visible');
   }, 2000);
 
   player.addEvent('ready', function () {


### PR DESCRIPTION
If jQuery $ isn't defined, onYouTubePlayerAPIReady and vimeoPlayerReady will fail. Replaced
$(...) with jQuery(...).
