### PR TITLE
Add ability to target a node

### DIFF
--- a/src/okvideo.js
+++ b/src/okvideo.js
@@ -29,8 +29,9 @@ var player, OKEvents, options;
       if (base.options.video === null) base.options.video = base.options.source; 
 
       var target = base.options.target || $('body');
-      console.log(target);
       var position = target[0] == $('body')[0] ? 'fixed' : 'absolute';
+
+      target.css({position: 'relative'});
 
       if (OKEvents.utils.isMobile()) {
         target.append('<div id="okplayer" style="position:' + position + ';left:0;top:0;overflow:hidden;z-index:-999;height:100%;width:100%;"></div>');


### PR DESCRIPTION
This adds the ability to target a specific node and should address #17 and #18.

``` javascript
$('.someClass').okvideo({
  source: '9bZkp7q19f0', 
  volume: 0, 
  loop: true,
  hd:true, 
  adproof: true,
  annotations: false
});
```
